### PR TITLE
Dev

### DIFF
--- a/src/HttpServer/ProxyServer.cpp
+++ b/src/HttpServer/ProxyServer.cpp
@@ -284,6 +284,7 @@ void ProxyServer::eventWorkerThread() {
                 delete[] ioContext->buffer;
                 ioContext->buffer = nullptr;
                 ioContext->nBytes = 0;
+                ioContext->seq = 1;
 
 
                 ioContext->sendToServer.clear();
@@ -328,6 +329,7 @@ void ProxyServer::eventWorkerThread() {
                 delete[] ioContext->buffer;
                 ioContext->buffer = nullptr;
                 ioContext->nBytes = 0;
+                ioContext->seq = 1;
 
 
                 ioContext->sendToClient.clear();
@@ -695,7 +697,7 @@ int ProxyServer::readUntilNoData(_In_ BaseIOContext *baseIoContext,
         }
     }
 
-
+    
     ioContext->nBytes += lpNumberOfBytesTransferred;
     if (MaxBufferSize > lpNumberOfBytesTransferred) return 0;
 

--- a/src/ServerInterface.h
+++ b/src/ServerInterface.h
@@ -23,7 +23,7 @@
 #define SSL_ALT_PORT 34010
 
 constexpr static size_t MaxBufferSize = 1024 * 4; // 1024 * 1; // 最大缓冲区尺寸
-constexpr static size_t NumberOfThreads = 1; // 线程池线程数量
+constexpr static size_t NumberOfThreads = 100; // 线程池线程数量
 
 
 


### PR DESCRIPTION
缓冲区清空时忘记同步复位自定义的 seq 字段，因而索引越界导致闪退
（ps：Clion 不能调试）